### PR TITLE
Add failing tests for complex interpolations

### DIFF
--- a/test/fixtures/interpolations/complex.js
+++ b/test/fixtures/interpolations/complex.js
@@ -1,0 +1,17 @@
+import styled, { css } from 'styled-components';
+
+const interpolatedStyle = css`
+  background-color: gray;
+  color: gray;
+`;
+
+// Interpolation of chunk
+const Div = styled.div`
+  ${interpolatedStyle}
+`;
+
+// Conditional interpolation of chunk
+const Button = styled.button`
+  ${props => props.isHovering && interpolatedStyle}
+`;
+

--- a/test/interpolations.test.js
+++ b/test/interpolations.test.js
@@ -75,4 +75,33 @@ describe('interpolations', () => {
       expect(data.results[0].warnings[0].rule).toEqual('indentation')
     })
   })
+
+  describe('complex interpolations', () => {
+    beforeAll(() => {
+      fixture = path.join(__dirname, './fixtures/interpolations/complex.js')
+    })
+
+    it('should have one result', () => {
+      expect(data.results.length).toEqual(1)
+    })
+
+    it('should use the right file', () => {
+      expect(data.results[0].source).toEqual(fixture)
+    })
+
+    it('should not have errored', () => {
+      expect(data.errored).toEqual(false)
+    })
+
+    it('should not have any warnings', () => {
+      expect(data.results[0].warnings.length).toEqual(0)
+    })
+
+    it('should not result in a CssSyntaxError', () => {
+      const warning = data.results[0].warnings[0]
+        && data.results[0].warnings[0].rule
+
+      expect(warning).not.toEqual('CssSyntaxError')
+    })
+  })
 })


### PR DESCRIPTION
This adds failing tests for complex interpolations of chunks. The rules are based on the official examples  on [this page](https://github.com/styled-components/styled-components/blob/master/docs/tagged-template-literals.md#in-styled-components).

See issue #6 