### PR TITLE
syntax update for stylelint npm scripts cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add a `lint:css` script to your `package.json`. This script will run `stylelint`
 ```JSON
 {
   "scripts": {
-    "lint:css": "stylelint './components/**/*.js'"
+    "lint:css": "stylelint \"./components/**/*.js\""
   }
 }
 ```


### PR DESCRIPTION
Using single quotes in the stylelint command didn't work for me (PC, Stylelint 7.7.1). This stackoverflow page simply suggested replacing single quotes with double: http://stackoverflow.com/questions/38814200/files-glob-patterns-specified-did-not-match-any-files - this fixed it for me. Checking out the stylelint docs I didn't see any reference to this issue but all examples used double quotes, so this should be safe.