### PR TITLE
Fixed: set `errored` to `false` if `warning` no contains errors.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,9 @@ module.exports = (/* options */) => ({
       prevWarnings.push(correctedWarning)
       return prevWarnings
     }, [])
-    
+
     if (newWarnings.length === 0) {
+      // eslint-disable-next-line no-param-reassign
       stylelintResult.errored = false
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,10 @@ module.exports = (/* options */) => ({
       prevWarnings.push(correctedWarning)
       return prevWarnings
     }, [])
+    
+    if (newWarnings.length === 0) {
+      stylelintResult.errored = false
+    }
 
     return Object.assign(stylelintResult, { warnings: newWarnings })
   },


### PR DESCRIPTION
Closes #22

BTW, i would recommend don't changed `stylelintResult`, just add node in `README.md` about disable `no-empty-source` and `no-missing-end-of-source-newline`, in next version we can change `stylelintResult` (example rename `warnings` to another name) and `stylelint-processor-styled-components` will cease to work as expected.