### PR TITLE
Docs: change quotes for better reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add a `lint:css` script to your `package.json`. This script will run `stylelint`
 ```JSON
 {
   "scripts": {
-    "lint:css": "stylelint \"./components/**/*.js\""
+    "lint:css": "stylelint './components/**/*.js'"
   }
 }
 ```


### PR DESCRIPTION
In the scripts, it works if using single quotes as well. This should improve the readability.