### PR TITLE
Add support for Typescript files. Closes #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.vscode
 *.log
 npm-debug.log*
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "eslint-plugin-import": "^2.0.1",
     "jest": "^16.0.2",
     "lodash": "^4.15.0",
-    "stylelint": "^7.3.0"
+    "stylelint": "^7.3.0",
+    "typescript": "^2.3.4",
+    "typescript-eslint-parser": "^3.0.0"
   },
   "dependencies": {
     "babel-traverse": "^6.16.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,5 @@
 const path = require('path')
-const babylon = require('babylon')
-const traverse = require('babel-traverse').default
-const isStyled = require('./utils/styled').isStyled
-const isHelper = require('./utils/styled').isHelper
-const isStyledImport = require('./utils/styled').isStyledImport
-
-const wrapSelector = require('./utils/general').wrapSelector
-const wrapKeyframes = require('./utils/general').wrapKeyframes
-const fixIndentation = require('./utils/general').fixIndentation
-
-const getTTLContent = require('./utils/tagged-template-literal.js').getTaggedTemplateLiteralContent
-const parseImports = require('./utils/parse').parseImports
-const getSourceMap = require('./utils/parse').getSourceMap
-
+const parse = require('./parsers/index')
 // TODO Fix ampersand in selectors
 // TODO ENFORCE THESE RULES
 // value-no-vendor-prefix – don't allow vendor prefixes
@@ -32,54 +19,13 @@ module.exports = (/* options */) => ({
   code(input, filepath) {
     const absolutePath = path.resolve(process.cwd(), filepath)
     sourceMapsCorrections[absolutePath] = {}
-    const ast = babylon.parse(input, {
-      sourceType: 'module',
-      plugins: [
-        'jsx',
-        'flow',
-        'objectRestSpread',
-        'decorators',
-        'classProperties',
-        'exportExtensions',
-        'asyncGenerators',
-        'functionBind',
-        'functionSent',
-        'dynamicImport',
-      ],
-    })
-
-    const extractedCSS = []
-    let importedNames = {
-      default: 'styled',
-      css: 'css',
-      keyframes: 'keyframes',
-      injectGlobal: 'injectGlobal',
-    }
-    traverse(ast, {
-      enter({ node }) {
-        if (isStyledImport(node)) {
-          importedNames = parseImports(node)
-          return
-        }
-
-        const helper = isHelper(node, importedNames)
-
-        if (!helper && !isStyled(node, importedNames.default)) return
-
-        const content = getTTLContent(node)
-        const fixedContent = fixIndentation(content).text
-        const wrapperFn = helper === 'keyframes' ? wrapKeyframes : wrapSelector
-        const wrappedContent = wrapperFn(fixedContent)
-        extractedCSS.push(wrappedContent)
-        // Save source location, merging existing corrections with current corrections
-        sourceMapsCorrections[absolutePath] = Object.assign(
+    const { extractedCSS, sourceMap } = parse(input, absolutePath)
+      // Save source location, merging existing corrections with current corrections
+    sourceMapsCorrections[absolutePath] = Object.assign(
           sourceMapsCorrections[absolutePath],
-          getSourceMap(extractedCSS.join('\n'), wrappedContent, node.loc.start.line)
+          sourceMap
         )
-      },
-    })
-
-    return extractedCSS.join('\n')
+    return extractedCSS
   },
   // Fix sourcemaps
   result(stylelintResult, filepath) {

--- a/src/parsers/babylon-parser.js
+++ b/src/parsers/babylon-parser.js
@@ -1,0 +1,17 @@
+const babylon = require('babylon')
+
+module.exports = (input) => babylon.parse(input, {
+  sourceType: 'module',
+  plugins: [
+    'jsx',
+    'flow',
+    'objectRestSpread',
+    'decorators',
+    'classProperties',
+    'exportExtensions',
+    'asyncGenerators',
+    'functionBind',
+    'functionSent',
+    'dynamicImport',
+  ],
+})

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,0 +1,59 @@
+const estreeParse = require('./babylon-parser')
+const typescriptParse = require('./typescript-parser')
+
+const traverse = require('babel-traverse').default
+const isStyled = require('../utils/styled').isStyled
+const isHelper = require('../utils/styled').isHelper
+const isStyledImport = require('../utils/styled').isStyledImport
+
+const wrapSelector = require('../utils/general').wrapSelector
+const wrapKeyframes = require('../utils/general').wrapKeyframes
+const fixIndentation = require('../utils/general').fixIndentation
+
+const getTTLContent = require('../utils/tagged-template-literal.js').getTaggedTemplateLiteralContent
+const parseImports = require('../utils/parse').parseImports
+const getSourceMap = require('../utils/parse').getSourceMap
+
+const processStyledComponentsFile = (ast) => {
+  const extractedCSS = []
+  let importedNames = {
+    default: 'styled',
+    css: 'css',
+    keyframes: 'keyframes',
+    injectGlobal: 'injectGlobal',
+  }
+  let sourceMap = {}
+  traverse(ast, {
+    noScope: true,
+    enter({ node }) {
+      if (isStyledImport(node)) {
+        importedNames = parseImports(node)
+        return
+      }
+      const helper = isHelper(node, importedNames)
+      if (!helper && !isStyled(node, importedNames.default)) return
+      const content = getTTLContent(node)
+      const fixedContent = fixIndentation(content).text
+      const wrapperFn = helper === 'keyframes' ? wrapKeyframes : wrapSelector
+      const wrappedContent = wrapperFn(fixedContent)
+      extractedCSS.push(wrappedContent)
+      sourceMap = Object.assign(sourceMap,
+                    getSourceMap(extractedCSS.join('\n'), wrappedContent, node.loc.start.line))
+    },
+  })
+
+  return {
+    extractedCSS: extractedCSS.join('\n'),
+    sourceMap,
+  }
+}
+
+module.exports = (input, absolutePath) => {
+  let ast = null
+  if (absolutePath.endsWith('.ts') || absolutePath.endsWith('.tsx')) {
+    ast = typescriptParse(input)
+  } else {
+    ast = estreeParse(input)
+  }
+  return processStyledComponentsFile(ast, absolutePath)
+}

--- a/src/parsers/parser-include-shebang.js
+++ b/src/parsers/parser-include-shebang.js
@@ -1,0 +1,28 @@
+function includeShebang(text, ast) {
+  if (!text.startsWith('#!')) {
+    return ast.comments
+  }
+
+  const index = text.indexOf('\n')
+  const shebang = text.slice(2, index)
+  const comment = {
+    type: 'Line',
+    value: shebang,
+    range: [0, index],
+    loc: {
+      source: null,
+      start: {
+        line: 1,
+        column: 0,
+      },
+      end: {
+        line: 1,
+        column: index,
+      },
+    },
+  }
+
+  return [comment].concat(ast.comments)
+}
+
+module.exports = includeShebang

--- a/src/parsers/typescript-parser.js
+++ b/src/parsers/typescript-parser.js
@@ -1,0 +1,16 @@
+const parser = require('typescript-eslint-parser')
+const includeShebang = require('./parser-include-shebang')
+
+module.exports = (input) => {
+  const ast = parser.parse(input, {
+    loc: true,
+    range: true,
+    tokens: true,
+    comment: true,
+    useJSXTextNode: true,
+    ecmaFeatures: { jsx: true },
+  })
+  delete ast.tokens
+  ast.comments = includeShebang(input, ast)
+  return ast
+}

--- a/test/fixtures/typescript/ts-syntax-invalid.ts
+++ b/test/fixtures/typescript/ts-syntax-invalid.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+export interface IAccordionContainerProps {
+    className?: string;
+    borderWidth: number,
+    onChange?(id: string): void;
+}
+export interface IAccordionContainerState {
+    selected: string;
+}
+
+export const AccordionContainerDiv = styled.div`
+       border: solid  ${(props: IAccordionContainerProps) => props.borderWidth}px;
+    border-bottom-width: 0;
+    width: auto;
+`;
+
+// ⚠️ EMPTY BLOCK ⚠️
+export const Button = styled.button`
+
+`
+
+// ⚠️ BAD INDENTATION ⚠️
+export const Button2 = styled.button`
+
+color: blue;
+`

--- a/test/fixtures/typescript/ts-syntax-jsx-invalid.tsx
+++ b/test/fixtures/typescript/ts-syntax-jsx-invalid.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  header: React.ReactNode;
+  body: React.ReactNode;
+}
+type SelectProps<T> = { items: T[] }
+class Select<T> extends React.Component<SelectProps<T>, any> { }
+
+class MyComponent extends React.Component<Props, {}> {
+    render() {
+        return <div>
+            {this.props.header}
+            {this.props.body}
+        </div>;
+    }
+}
+
+const DecoratedComp = styled(MyComponent)`
+     border: 2px;
+`;

--- a/test/fixtures/typescript/ts-syntax-valid.ts
+++ b/test/fixtures/typescript/ts-syntax-valid.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+export interface IAccordionContainerProps {
+    className?: string;
+    borderWidth: number,
+    onChange?(id: string): void;
+}
+export interface IAccordionContainerState {
+    selected: string;
+}
+
+export const AccordionContainerDiv = styled.div`
+  border: solid  ${(props: IAccordionContainerProps) => props.borderWidth}px;
+  border-bottom-width: 0;
+  width: auto;
+`;

--- a/test/typescript.test.js
+++ b/test/typescript.test.js
@@ -1,0 +1,60 @@
+const stylelint = require('stylelint')
+const path = require('path')
+
+const processor = path.join(__dirname, '../src/index.js')
+const rules = {
+  'block-no-empty': true,
+  indentation: 2,
+  'rule-empty-line-before': ['always-multi-line', {
+    except: ['first-nested'],
+    ignore: ['after-comment'],
+  }],
+}
+const doLint = (fixture, done) => stylelint.lint({
+  files: [fixture],
+  syntax: 'scss',
+  config: {
+    processors: [processor],
+    rules,
+  },
+}).then((result) => result).catch((err) => {
+    // eslint-disable-next-line
+    console.log(err)
+  done()
+  return err
+})
+
+describe('Typescript files, both TS and TSX should parse and report any errors correctly', () => {
+  it('should parse styled components code in TS files and report correctly the errors encountered', (done) => {
+    const fixture = path.join(__dirname, './fixtures/typescript/ts-syntax-invalid.ts')
+    doLint(fixture, done).then((data) => {
+      expect(data.results.length).toEqual(1)
+      expect(data.results[0].warnings.length).toEqual(5)
+      expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+      expect(data.results[0].warnings[1].rule).toEqual('indentation')
+      expect(data.results[0].warnings[2].rule).toEqual('indentation')
+      expect(data.results[0].warnings[3].rule).toEqual('indentation')
+      expect(data.results[0].warnings[4].rule).toEqual('indentation')
+      done()
+    })
+  })
+
+  it('should not report errors when there are NOT any in a typescript files', (done) => {
+    const fixture = path.join(__dirname, './fixtures/typescript/ts-syntax-valid.ts')
+    doLint(fixture, done).then((data) => {
+      expect(data.results.length).toEqual(1)
+      expect(data.results[0].warnings.length).toEqual(0)
+      done()
+    })
+  })
+
+  it('should report errors in TSX files(typescript + JSX)', (done) => {
+    const fixture = path.join(__dirname, './fixtures/typescript/ts-syntax-jsx-invalid.tsx')
+    doLint(fixture, done).then((data) => {
+      expect(data.results.length).toEqual(1)
+      expect(data.results[0].warnings.length).toEqual(1)
+      expect(data.results[0].warnings[0].rule).toEqual('indentation')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
 - Add support for .ts, .tsx parsing and reporting.
-  A small refactor to allow integration of new parser cleanly
-  A few tests demonstrating parsing and error reporting in both .ts and .tsx files 