### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+### 0.1.2
+* fix: move typescript from dependencies to devdependencies
+
+### 0.1.1
+* add typescript support
+* add newline between components' styles
+* use unique name for each wrapped selector
+* fix: set stylelint result `errored` to `false` if `warning` does not contain errors
+
+### 0.1.0
+
+* initial release
+
+### 0.0.1 - 0.0.4
+
+* working draft


### PR DESCRIPTION
Eventually an automated solution might be better, but at least we now have a changelog. Initial versions up until 0.1.0 are listed as working drafts.

0.1.1 changes list some parser changes that aren't immediately user facing, but since we don't having a shareable config yet, they might still affect users and are useful for them to know about in my opinion.

Closes #36