### PR TITLE
Fixed multiple interpolations in a property

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -45,7 +45,7 @@ const isLastLineWhitespaceOnly = text => {
       return false
     }
   }
-  return true
+  return false
 }
 
 // eslint-disable-next-line no-return-assign

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -45,7 +45,23 @@ const isLastLineWhitespaceOnly = text => {
       return false
     }
   }
-  return false
+  return true
+}
+
+/**
+ * Checks if text is empty or space only
+ */
+const isEmptyOrSpaceOnly = text => {
+  if (text === '') {
+    return true
+  }
+  for (let i = text.length - 1; i >= 0; i -= 1) {
+    const char = text.charAt(i)
+    if (char !== '\t' && char !== ' ') {
+      return false
+    }
+  }
+  return true
 }
 
 // eslint-disable-next-line no-return-assign
@@ -56,3 +72,4 @@ exports.wrapKeyframes = wrapKeyframes
 exports.wrapSelector = wrapSelector
 exports.fixIndentation = fixIndentation
 exports.isLastLineWhitespaceOnly = isLastLineWhitespaceOnly
+exports.isEmptyOrSpaceOnly = isEmptyOrSpaceOnly

--- a/src/utils/tagged-template-literal.js
+++ b/src/utils/tagged-template-literal.js
@@ -1,4 +1,5 @@
 const isLastLineWhitespaceOnly = require('./general').isLastLineWhitespaceOnly
+const isEmptyOrSpaceOnly = require('./general').isEmptyOrSpaceOnly
 
 /**
  * Check if a node is a tagged template literal
@@ -21,7 +22,7 @@ const interleave = (quasis, expressions) => {
     const expression = expressions[i]
 
     css += prevText
-    if (isLastLineWhitespaceOnly(prevText)) {
+    if (isLastLineWhitespaceOnly(prevText) && !isEmptyOrSpaceOnly(prevText)) {
       css += `-styled-mixin: ${expression.name}`
       if (nextText.charAt(0) !== ';') {
         css += ';'

--- a/test/fixtures/interpolations/valid.js
+++ b/test/fixtures/interpolations/valid.js
@@ -71,3 +71,11 @@ const Button6 = styled.button`
   `}
   background: blue;
 `
+
+// multi interpolations within a property
+const borderWidth = '1px'
+const borderStyle = 'solid'
+const Button7 = styled.button`
+  width: 20px;
+  border: ${borderWidth} ${borderStyle} ${color};
+`

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -41,15 +41,15 @@ describe('utils', () => {
 
   describe('isLastLineWhitespaceOnly', () => {
     it('should return true for empty string', () => {
-      expect(isLastLineWhitespaceOnly('')).toEqual(true)
+      expect(isLastLineWhitespaceOnly('')).toEqual(false)
     })
 
     it('should return true for string of spaces', () => {
-      expect(isLastLineWhitespaceOnly('   ')).toEqual(true)
+      expect(isLastLineWhitespaceOnly('   ')).toEqual(false)
     })
 
     it('should return true for string of spaces and tabs', () => {
-      expect(isLastLineWhitespaceOnly(' \t  ')).toEqual(true)
+      expect(isLastLineWhitespaceOnly(' \t  ')).toEqual(false)
     })
 
     it('should return false for string with something other than space and tab', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,6 @@
 const interleave = require('../src/utils/tagged-template-literal').interleave
 const isLastLineWhitespaceOnly = require('../src/utils/general').isLastLineWhitespaceOnly
+const isEmptyOrSpaceOnly = require('../src/utils/general').isEmptyOrSpaceOnly
 
 describe('utils', () => {
   describe('interleave', () => {
@@ -41,15 +42,15 @@ describe('utils', () => {
 
   describe('isLastLineWhitespaceOnly', () => {
     it('should return true for empty string', () => {
-      expect(isLastLineWhitespaceOnly('')).toEqual(false)
+      expect(isLastLineWhitespaceOnly('')).toEqual(true)
     })
 
     it('should return true for string of spaces', () => {
-      expect(isLastLineWhitespaceOnly('   ')).toEqual(false)
+      expect(isLastLineWhitespaceOnly('   ')).toEqual(true)
     })
 
     it('should return true for string of spaces and tabs', () => {
-      expect(isLastLineWhitespaceOnly(' \t  ')).toEqual(false)
+      expect(isLastLineWhitespaceOnly(' \t  ')).toEqual(true)
     })
 
     it('should return false for string with something other than space and tab', () => {
@@ -58,6 +59,24 @@ describe('utils', () => {
 
     it('should return true if last line has only space and tab', () => {
       expect(isLastLineWhitespaceOnly('not space\n  ')).toEqual(true)
+    })
+  })
+
+  describe('isEmptyOrSpaceOnly', () => {
+    it('should return true for empty string', () => {
+      expect(isEmptyOrSpaceOnly('')).toEqual(true)
+    })
+
+    it('should return true for consecutive empty string', () => {
+      expect(isEmptyOrSpaceOnly(' ')).toEqual(true)
+    })
+
+    it('should return true for string of spaces and tabs', () => {
+      expect(isEmptyOrSpaceOnly(' \t  ')).toEqual(true)
+    })
+
+    it('should return false for string of newline', () => {
+      expect(isEmptyOrSpaceOnly('\n')).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
related to #20 #21

This change enable to use multiple interpolations in a property at once.

```
  width: 20px;
  border: ${borderWidth} ${borderStyle} ${color};
```
is now translated to:

```
 width: 20px;
 border: $borderWidth -styled-mixin: borderStyle; -styled-mixin: color;
```
This changes above to: 

```
 width: 20px;
 border: $borderWidth $borderStyle $color;
```

Cc: @mxstbr 