### PR TITLE
Add stylelint-disable note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,17 @@ npm run lint:css
 ```
 
 ### Syntax notes
-#### stylelint-disable
-In order for `stylelint-processor-styled-components` to parse your `stylelint-disable` comments they must be inside the actual Styled Components CSS as such:
+#### Turning rules off from within your CSS
+In order for `stylelint-processor-styled-components` to parse your `stylelint-disable` comments (see the [stylelint documentation](https://stylelint.io/user-guide/configuration/#turning-rules-off-from-within-your-css) for all allowed syntax) they must be inside the actual Styled Components CSS as such:
 
 **Wrong**:
 ```
-/* stylelint-disable declaration-empty-line-before */
+/* stylelint-disable color-named */
 import React from 'react';
 import styled from 'styled-components';
 
-const media = ...
-
 const Wrapper = styled.div`
   background-color: red;
-  
-  ${media.desktop`background-color: blue;`}
-  ${media.tablet`background-color: yellow;`}
-  ${media.phone`background-color: purple;`}
 `;
 ```
 **Right**:
@@ -81,15 +75,9 @@ const Wrapper = styled.div`
 import React from 'react';
 import styled from 'styled-components';
 
-const media = ...
-
 const Wrapper = styled.div`
   /* stylelint-disable declaration-empty-line-before */
   background-color: red;
-  
-  ${media.desktop`background-color: blue;`}
-  ${media.tablet`background-color: yellow;`}
-  ${media.phone`background-color: purple;`}
 `;
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,44 @@ Now you can lint your CSS by running this script! 🎉
 npm run lint:css
 ```
 
+### Syntax notes
+#### stylelint-disable
+In order for `stylelint-processor-styled-components` to parse your `stylelint-disable` comments they must be inside the actual Styled Components CSS as such:
+
+**Wrong**:
+```
+/* stylelint-disable declaration-empty-line-before */
+import React from 'react';
+import styled from 'styled-components';
+
+const media = ...
+
+const Wrapper = styled.div`
+  background-color: red;
+  
+  ${media.desktop`background-color: blue;`}
+  ${media.tablet`background-color: yellow;`}
+  ${media.phone`background-color: purple;`}
+`;
+```
+**Right**:
+```
+import React from 'react';
+import styled from 'styled-components';
+
+const media = ...
+
+const Wrapper = styled.div`
+  /* stylelint-disable declaration-empty-line-before */
+  background-color: red;
+  
+  ${media.desktop`background-color: blue;`}
+  ${media.tablet`background-color: yellow;`}
+  ${media.phone`background-color: purple;`}
+`;
+```
+
+
 ## License
 
 Licensed under the MIT License, Copyright © 2016 Maximilian Stoiber. See [LICENSE.md](./LICENSE.md) for more information!


### PR DESCRIPTION
I was trying to think of a better example for a rule to break, but as I'm new to stylelint I couldn't find a good one yet, if anyone has a better example feel free to suggest that.

Especially using the media queries (though it is an example in the docs) could be a bit confusing I guess, but yeah, as I'm new to stylelint it was just hard to think of good examples.

It'd be neat to have in here though so no one else submits erroneous issues like I did :).