### PR TITLE
Beef up interpolation tests and interleave function to handle more edge cases

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -46,7 +46,11 @@ const reverseString = str => str.split('').reverse().join('')
 const isLastDeclarationCompleted = text => {
   const reversedText = reverseString(text)
   const lastNonWhitespaceChar = nextNonWhitespaceChar(reversedText)
-  if (lastNonWhitespaceChar === ';' || lastNonWhitespaceChar === null) {
+  if (
+    lastNonWhitespaceChar === ';' ||
+    lastNonWhitespaceChar === '}' ||
+    lastNonWhitespaceChar === null
+  ) {
     return true
   } else {
     return false

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -60,5 +60,6 @@ const wrapKeyframes = content => `@keyframes {${content}}\n`
 exports.wrapKeyframes = wrapKeyframes
 exports.wrapSelector = wrapSelector
 exports.fixIndentation = fixIndentation
+exports.reverseString = reverseString
 exports.nextNonWhitespaceChar = nextNonWhitespaceChar
 exports.isLastDeclarationCompleted = isLastDeclarationCompleted

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -33,7 +33,7 @@ const fixIndentation = str => {
 }
 
 const nextNonWhitespaceChar = text => {
-  const matches = text.match(/^\s*(.)/)
+  const matches = text.match(/^\s*([^\s])/)
   if (matches) {
     return matches[1]
   } else {

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -32,36 +32,25 @@ const fixIndentation = str => {
   }
 }
 
-/**
- * Checks if last line of text has whitespaces only
- */
-const isLastLineWhitespaceOnly = text => {
-  for (let i = text.length - 1; i >= 0; i -= 1) {
-    const char = text.charAt(i)
-    if (char === '\n') {
-      return true
-    }
-    if (char !== '\t' && char !== ' ') {
-      return false
-    }
+const nextNonWhitespaceChar = text => {
+  const matches = text.match(/^\s*(.)/)
+  if (matches) {
+    return matches[1]
+  } else {
+    return null
   }
-  return true
 }
 
-/**
- * Checks if text is empty or space only
- */
-const isEmptyOrSpaceOnly = text => {
-  if (text === '') {
+const reverseString = str => str.split('').reverse().join('')
+
+const isLastDeclarationCompleted = text => {
+  const reversedText = reverseString(text)
+  const lastNonWhitespaceChar = nextNonWhitespaceChar(reversedText)
+  if (lastNonWhitespaceChar === ';' || lastNonWhitespaceChar === null) {
     return true
+  } else {
+    return false
   }
-  for (let i = text.length - 1; i >= 0; i -= 1) {
-    const char = text.charAt(i)
-    if (char !== '\t' && char !== ' ') {
-      return false
-    }
-  }
-  return true
 }
 
 // eslint-disable-next-line no-return-assign
@@ -71,5 +60,5 @@ const wrapKeyframes = content => `@keyframes {${content}}\n`
 exports.wrapKeyframes = wrapKeyframes
 exports.wrapSelector = wrapSelector
 exports.fixIndentation = fixIndentation
-exports.isLastLineWhitespaceOnly = isLastLineWhitespaceOnly
-exports.isEmptyOrSpaceOnly = isEmptyOrSpaceOnly
+exports.nextNonWhitespaceChar = nextNonWhitespaceChar
+exports.isLastDeclarationCompleted = isLastDeclarationCompleted

--- a/test/fixtures/interpolations/valid.js
+++ b/test/fixtures/interpolations/valid.js
@@ -90,3 +90,19 @@ const Button8 = styled.button`
   ${`color: ${color};`}
   ${`background: blue;`}
 `
+// Simple interpolations in one-line css
+const display = 'block'
+const colorExpression = 'color: red;'
+// prettier-ignore
+const Button9 = styled.button`
+  display: ${display}; ${colorExpression}
+`
+
+// Complex interpolations in one-line css
+const display = 'block'
+const colorExpression = 'color: red;'
+const backgroundExpression = 'background: blue;'
+// prettier-ignore
+const Button9 = styled.button`
+  display: ${display}; ${colorExpression} ${backgroundExpression}
+`

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -290,5 +290,15 @@ describe('utils', () => {
           `)
       ).toBe(true)
     })
+
+    it('handles declaration blocks', () => {
+      const prevCSS = `
+        @media screen and (max-width: 600px) {
+          display: block;
+          color: red;
+        }
+      `
+      expect(fn(prevCSS)).toBe(true)
+    })
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,4 @@
 const interleave = require('../src/utils/tagged-template-literal').interleave
-const isLastLineWhitespaceOnly = require('../src/utils/general').isLastLineWhitespaceOnly
-const isEmptyOrSpaceOnly = require('../src/utils/general').isEmptyOrSpaceOnly
 
 describe('utils', () => {
   describe('interleave', () => {
@@ -157,48 +155,8 @@ describe('utils', () => {
         }
       ]
       expect(interleave(quasis2, expressions2)).toEqual(
-        '\n  display: $dummyValue; -styled-mixin0: dummyValue\n'
+        '\n  display: $dummyValue; -styled-mixin0: dummyValue;\n'
       )
-    })
-  })
-
-  describe('isLastLineWhitespaceOnly', () => {
-    it('should return true for empty string', () => {
-      expect(isLastLineWhitespaceOnly('')).toEqual(true)
-    })
-
-    it('should return true for string of spaces', () => {
-      expect(isLastLineWhitespaceOnly('   ')).toEqual(true)
-    })
-
-    it('should return true for string of spaces and tabs', () => {
-      expect(isLastLineWhitespaceOnly(' \t  ')).toEqual(true)
-    })
-
-    it('should return false for string with something other than space and tab', () => {
-      expect(isLastLineWhitespaceOnly('not space')).toEqual(false)
-    })
-
-    it('should return true if last line has only space and tab', () => {
-      expect(isLastLineWhitespaceOnly('not space\n  ')).toEqual(true)
-    })
-  })
-
-  describe('isEmptyOrSpaceOnly', () => {
-    it('should return true for empty string', () => {
-      expect(isEmptyOrSpaceOnly('')).toEqual(true)
-    })
-
-    it('should return true for consecutive empty string', () => {
-      expect(isEmptyOrSpaceOnly(' ')).toEqual(true)
-    })
-
-    it('should return true for string of spaces and tabs', () => {
-      expect(isEmptyOrSpaceOnly(' \t  ')).toEqual(true)
-    })
-
-    it('should return false for string of newline', () => {
-      expect(isEmptyOrSpaceOnly('\n')).toEqual(false)
     })
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -38,6 +38,128 @@ describe('utils', () => {
         '\n  display: block;\n  color: $dummyValue;\n  background: blue;\n'
       )
     })
+
+    it('converts interpolated expressions to dummy mixins', () => {
+      const quasis = [
+        {
+          value: {
+            raw: '\n  display: block;\n  '
+          }
+        },
+        {
+          value: {
+            raw: '\n  background: blue;\n'
+          }
+        }
+      ]
+      const expressions = [
+        {
+          name: undefined
+        }
+      ]
+      expect(interleave(quasis, expressions)).toEqual(
+        '\n  display: block;\n  -styled-mixin0: dummyValue;\n  background: blue;\n'
+      )
+    })
+
+    it('correctly converts several interpolations within a single property', () => {
+      const quasis = [
+        {
+          value: {
+            raw: '\n  display: block;\n  border: '
+          }
+        },
+        {
+          value: {
+            raw: ' '
+          }
+        },
+        {
+          value: {
+            raw: ' '
+          }
+        },
+        {
+          value: {
+            raw: ';\n  background: blue;\n'
+          }
+        }
+      ]
+      const expressions = [
+        {
+          name: 'borderWidth'
+        },
+        {
+          name: 'borderStyle'
+        },
+        {
+          name: 'color'
+        }
+      ]
+      expect(interleave(quasis, expressions)).toEqual(
+        '\n  display: block;\n  border: $dummyValue $dummyValue $dummyValue;\n  background: blue;\n'
+      )
+    })
+
+    it('correctly handles several interpolations in single line of css', () => {
+      const quasis1 = [
+        {
+          value: {
+            raw: '\n  display: '
+          }
+        },
+        {
+          value: {
+            raw: '; background: '
+          }
+        },
+        {
+          value: {
+            raw: ';\n'
+          }
+        }
+      ]
+      const expressions1 = [
+        {
+          name: 'display'
+        },
+        {
+          name: 'background'
+        }
+      ]
+      expect(interleave(quasis1, expressions1)).toEqual(
+        '\n  display: $dummyValue; background: $dummyValue;\n'
+      )
+
+      const quasis2 = [
+        {
+          value: {
+            raw: '\n  display: '
+          }
+        },
+        {
+          value: {
+            raw: '; '
+          }
+        },
+        {
+          value: {
+            raw: '\n'
+          }
+        }
+      ]
+      const expressions2 = [
+        {
+          name: 'display'
+        },
+        {
+          name: undefined
+        }
+      ]
+      expect(interleave(quasis2, expressions2)).toEqual(
+        '\n  display: $dummyValue; -styled-mixin0: dummyValue\n'
+      )
+    })
   })
 
   describe('isLastLineWhitespaceOnly', () => {


### PR DESCRIPTION
I found a few edge cases, and while working on #59 I also just saw that tests for `interleave` were a bit lacking, so I felt like adding a few tests there that weren't braking but just for good form as well. I might have some more edge cases in mind as well. This is WIP but will resolve #62 and is related to #52.

It is branched off from #59 at the moment so until that is merged the diff here is a bit overkill.