### PR TITLE
Fix indented TTL case

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm run lint:css
 Turning off rules with `stylelint-disable`-like comments (see the [stylelint documentation](https://stylelint.io/user-guide/configuration/#turning-rules-off-from-within-your-css) for all allowed syntax) is fully supported inside and outside of the tagged template literals, do note though that what actually happens behind the scene is that all `stylelint-(disable|enable)` comments are moved into the compiled css that is actually linted, so something like this:
 
 
-```
+```js
 /* stylelint-disable */
 import React from 'react';
 import styled from 'styled-components';
@@ -74,7 +74,7 @@ const Wrapper = styled.div`
 `;
 ```
 or even
-```
+```js
 /* stylelint-disable */
 import React from 'react';
 import styled from 'styled-components';
@@ -89,6 +89,42 @@ would throw a stylelint error similar to `All rules have already been disabled (
 
 #### Interpolation linting
 We do not currently support linting interpolations as it could be a big performance hit though we aspire to have at least partial support in the future. You can of course lint your own mixins in their separate files, but it won't be linted in context, the implementation currently just inserts relevant dummy values. This, we are afraid, means you won't be able to lint cases such as `declaration-block-no-duplicate-properties` etc. and won't be able to lint outside mixins such as [polished](https://github.com/styled-components/polished).
+
+#### Template literal style and indentation
+In order to have stylelint correctly apply indentation rules we need to do a bit of opinionated preprocessing on the `styled-components` styles, which results in us only officially supporting one coding style when it comes to `styled-components` tagged template literals. This style consists of always placing the closing backtick on the base level of indentation as follows:
+
+**Right**
+```js
+const Button = styled.button`
+  color: red;
+`
+```
+
+```js
+if (condition) {
+  const Button = styled.button`
+    color: red;
+  `
+}
+```
+
+**Wrong**
+```js
+if (condition) {
+  const Button = styled.button`
+    color: red;
+`
+}
+```
+
+```js
+if (condition) {
+  const Button = styled.button`
+    color: red;`
+}
+```
+
+It may be that other tagged template literal styles are coincidentally supported, but no issues will be handled regarding indentation unless the above style was used.
 
 ## License
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -8,11 +8,17 @@ let count = 0
  */
 const fixIndentation = str => {
   // Get whitespaces
-  let match = str.match(/^[ \t]*(?=\S|$)/gm)
-  // Remove first, empty item
+  const match = str.match(/^[ \t]*(?=\S|$)/gm)
+
+  // Handle oneline TTL case
+  if (match.length === 1) {
+    return {
+      text: str,
+      indentColumns: 0
+    }
+  }
+  // Remove first, empty item, and if it is a oneline TTL we already handled it
   match.splice(0, 1)
-  // Remove empty lines
-  match = match.map(x => (x.length < match[match.length - 1].length ? '  ' : x))
 
   if (!match) {
     return {
@@ -21,14 +27,14 @@ const fixIndentation = str => {
     }
   }
 
-  // Get the minimum amount of indentation
-  const indent = Math.min(...match.map(x => x.length))
-  const re = new RegExp(`^[ \\t]{${indent}}`, 'gm')
+  // Get the base level of indentation assuming standard javascript TTL style
+  const baseIndentationLength = match[match.length - 1].length
+  const re = new RegExp(`^[ \\t]{${baseIndentationLength}}`, 'gm')
 
   return {
     // Remove the min indentation from every line
-    text: indent > 0 ? str.replace(re, '') : str,
-    indentColumns: indent
+    text: baseIndentationLength > 0 ? str.replace(re, '') : str,
+    indentColumns: baseIndentationLength
   }
 }
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -10,30 +10,23 @@ const fixIndentation = str => {
   // Get whitespaces
   const match = str.match(/^[ \t]*(?=\S|$)/gm)
 
-  // Handle oneline TTL case
-  if (match.length === 1) {
-    return {
-      text: str,
-      indentColumns: 0
-    }
-  }
-  // Remove first, empty item, and if it is a oneline TTL we already handled it
-  match.splice(0, 1)
-
-  if (!match) {
+  // Handle oneline TTL case and empty line etc.
+  if (!match || match.length <= 1) {
     return {
       text: str,
       indentColumns: 0
     }
   }
 
-  // Get the base level of indentation assuming standard javascript TTL style
+  // We enforce that final backtick should be at base indentation level
   const baseIndentationLength = match[match.length - 1].length
-  const re = new RegExp(`^[ \\t]{${baseIndentationLength}}`, 'gm')
-
+  // Remove whitespace on empty lines before reindenting
+  const emptyLinesHandled = str.replace(/^[ \t]$/gm, '')
+  // Normalize indentation by removing common indent
+  const re = new RegExp(String.raw`^[ \t]{${baseIndentationLength}}`, 'gm')
+  const reIndentedString = emptyLinesHandled.replace(re, '')
   return {
-    // Remove the min indentation from every line
-    text: baseIndentationLength > 0 ? str.replace(re, '') : str,
+    text: reIndentedString,
     indentColumns: baseIndentationLength
   }
 }

--- a/test/fixtures/hard/indentation.js
+++ b/test/fixtures/hard/indentation.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components'
+import styled, { keyframes, css } from 'styled-components'
 
 // None of the below should throw indentation errors
 const Comp = () => {
@@ -33,4 +33,17 @@ const animations = {
       opacity: 1;
     }
   `
+}
+
+const helper = condition => {
+  if (condition) {
+    return css`
+      color: red;
+
+      &:hover {
+        color: blue;
+      }
+    `
+  }
+  return null
 }

--- a/test/fixtures/hard/invalid-indentation.js
+++ b/test/fixtures/hard/invalid-indentation.js
@@ -25,3 +25,48 @@ const Comp2 = () => {
 
   return InnerComp()
 }
+
+// The below don't follow our specifications of keeping closing backtick on base indentation level
+// ⚠ 3 indentation errors ⚠
+const Comp3 = () => {
+  const InnerComp = () => {
+    const Button = styled.button`
+      color: blue;
+      background: red;
+      display: block;
+`
+
+    return Button
+  }
+
+  return InnerComp()
+}
+
+// ⚠ 3 indentation errors ⚠
+const Comp4 = () => {
+  const InnerComp = () => {
+    const Button = styled.button`
+      color: blue;
+      background: red;
+      display: block;`
+
+    return Button
+  }
+
+  return InnerComp()
+}
+
+// ⚠ 3 indentation errors ⚠
+const Comp5 = () => {
+  const InnerComp = () => {
+    const Button = styled.button`
+      color: blue;
+      background: red;
+      display: block;
+  `
+
+    return Button
+  }
+
+  return InnerComp()
+}

--- a/test/hard.test.js
+++ b/test/hard.test.js
@@ -73,8 +73,8 @@ describe('hard', () => {
         expect(data.errored).toEqual(true)
       })
 
-      it('should have 4 warnings', () => {
-        expect(data.results[0].warnings.length).toEqual(4)
+      it('should have 13 warnings', () => {
+        expect(data.results[0].warnings.length).toEqual(13)
       })
 
       it('should all be indentation warnings', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,6 +3,7 @@ const isLastDeclarationCompleted = require('../src/utils/general').isLastDeclara
 const nextNonWhitespaceChar = require('../src/utils/general').nextNonWhitespaceChar
 const reverseString = require('../src/utils/general').reverseString
 const isStylelintComment = require('../src/utils/general').isStylelintComment
+const fixIndentation = require('../src/utils/general').fixIndentation
 
 describe('utils', () => {
   describe('interleave', () => {
@@ -357,6 +358,20 @@ describe('utils', () => {
 
     it('should handle whitespace in start and end', () => {
       expect(fn('   \tstylelint-disable   \t')).toBe(true)
+    })
+  })
+
+  describe('fixIndentation', () => {
+    // We only check the one-line case for now as the rest is be covered thoroughly in hard.test.js
+    it('leaves one-line css alone', () => {
+      const test1 = 'display: block;'
+      expect(fixIndentation(test1).text).toBe(test1)
+
+      const test2 = '       display: block;'
+      expect(fixIndentation(test2).text).toBe(test2)
+
+      const test3 = '\t\tdisplay:block;'
+      expect(fixIndentation(test3).text).toBe(test3)
     })
   })
 })


### PR DESCRIPTION
This resolves #51.

Problem was that when replacing empty lines we were assuming base indentation was always 2 spaces, so in the min function it would always find 2 as the minimum if base indentation was actually more.

I changed it to assuming that the last backtick of the TTL is put on the level of the "base indentation level" which I think is a quite fair assumption, any better ideas?

Also will just put a comment in the code in one place when I submit the PR for something I was curious about.

I think it could probably be merged in now, could be I put in a few more tests tomorrow for oneline stuff etc. ? and more specifically for the issue that was found to be the root instead of just the specific case submitted in the issue.