### PR TITLE
Add reference to stylelint-custom-processor-loader to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ Now you can lint your CSS by running this script! 🎉
 npm run lint:css
 ```
 
+### Webpack
+
+For use with Webpack you can use the [`stylelint-custom-processor-loader`](https://github.com/emilgoldsmith/stylelint-custom-processor-loader).
+
 ### Syntax notes
 #### Turning rules off from within your CSS
+
 Turning off rules with `stylelint-disable`-like comments (see the [stylelint documentation](https://stylelint.io/user-guide/configuration/#turning-rules-off-from-within-your-css) for all allowed syntax) is fully supported inside and outside of the tagged template literals, do note though that what actually happens behind the scene is that all `stylelint-(disable|enable)` comments are moved into the compiled css that is actually linted, so something like this:
 
 
@@ -89,9 +94,11 @@ const Wrapper = styled.div`
 would throw a stylelint error similar to `All rules have already been disabled (CssSyntaxError)`.
 
 #### Interpolation linting
+
 We do not currently support linting interpolations as it could be a big performance hit though we aspire to have at least partial support in the future. You can of course lint your own mixins in their separate files, but it won't be linted in context, the implementation currently just inserts relevant dummy values. This, we are afraid, means you won't be able to lint cases such as `declaration-block-no-duplicate-properties` etc. and won't be able to lint outside mixins such as [polished](https://github.com/styled-components/polished).
 
 #### Template literal style and indentation
+
 In order to have stylelint correctly apply indentation rules we need to do a bit of opinionated preprocessing on the `styled-components` styles, which results in us only officially supporting one coding style when it comes to `styled-components` tagged template literals. This style consists of always placing the closing backtick on the base level of indentation as follows:
 
 **Right**


### PR DESCRIPTION
I think my Webpack loader is ready to see the light with core features etc. at least. I'd love to add it to the README here in a combination of shameless promotion of my own npm module and also just because I know I really wanted this when I started using our processor.

P.S: I stole your good idea of the gif in the README but upgraded it with the hot reloading webpack allows ;).