### PR TITLE
Update Greenkeeper Ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,14 @@
     "ignore": [
       "eslint",
       "eslint-plugin-import",
-      "typescript"
+      "eslint-config-airbnb-base",
+      "babel-cli",
+      "babel-preset-latest",
+      "husky",
+      "jest",
+      "lint-staged",
+      "lodash",
+      "prettier"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Updated Greenkeeper Ignore to not update any of our devDependencies that aren't directly related to the performance of the repo. (also removed Typescript from the ignore as I guess it could potentially be important to track the changes of that for our Typescript support, yes?)

This would also close #120 