### PR TITLE
Wrap whole transform block in try/catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ const DEFAULT_OPTIONS = {
 module.exports = options => ({
   // Get string for stylelint to lint
   code(input, filepath) {
-    const absolutePath = path.resolve(process.cwd(), filepath)
-    sourceMapsCorrections[absolutePath] = {}
     try {
+      const absolutePath = path.resolve(process.cwd(), filepath)
+      sourceMapsCorrections[absolutePath] = {}
       const { extractedCSS, sourceMap } = parse(
         input,
         absolutePath,


### PR DESCRIPTION
This will catch errors when filepath is undefined.

![screen shot 2017-11-25 at 05 59 43](https://user-images.githubusercontent.com/8881674/33227577-e69a305c-d1a5-11e7-8241-6936b272edd6.png)

Happens when viewing diff from git tab in vscode.