### PR TITLE
Fix if no file name given

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const parse = require('./parsers/index')
 
+let inputId = 1
 const interpolationLinesMap = {}
 const sourceMapsCorrections = {}
 const DEFAULT_OPTIONS = {
@@ -11,7 +12,14 @@ module.exports = options => ({
   // Get string for stylelint to lint
   code(input, filepath) {
     try {
-      const absolutePath = path.resolve(process.cwd(), filepath)
+      let absolutePath
+      if (filepath) {
+        absolutePath = path.resolve(process.cwd(), filepath)
+      } else {
+        absolutePath = `<input css ${inputId}>`
+        inputId += 1
+      }
+
       sourceMapsCorrections[absolutePath] = {}
       const { extractedCSS, interpolationLines, sourceMap } = parse(
         input,

--- a/test/nofiles.test.js
+++ b/test/nofiles.test.js
@@ -62,35 +62,9 @@ describe('no files', () => {
     })
   })
 
-  describe('not existed codeFilename', () => {
+  describe('has codeFilename', () => {
     beforeAll(() => {
-      codeFilename = 'not-existed-file'
-    })
-
-    it('should have one result', () => {
-      expect(data.results.length).toEqual(1)
-    })
-
-    it('should use the right file', () => {
-      expect(data.results[0].source).toEqual('<input css 7>')
-    })
-
-    it('should have errored', () => {
-      expect(data.errored).toEqual(true)
-    })
-
-    it('should have one warnings', () => {
-      expect(data.results[0].warnings.length).toEqual(1)
-    })
-
-    it('should have the right line number', () => {
-      expect(data.results[0].warnings[0].line).toEqual(3)
-    })
-  })
-
-  describe('existed codeFilename', () => {
-    beforeAll(() => {
-      codeFilename = 'package.json'
+      codeFilename = 'somefile.js'
     })
 
     it('should have one result', () => {

--- a/test/nofiles.test.js
+++ b/test/nofiles.test.js
@@ -1,0 +1,116 @@
+const stylelint = require('stylelint')
+const path = require('path')
+
+const code = `import styled from 'styled-components';
+const StyledTable = styled(StyledTableBase)\`
+color: red;
+\``
+const processor = path.join(__dirname, '../lib/index.js')
+const rules = {
+  indentation: 2
+}
+
+describe('no files', () => {
+  let codeFilename
+  let data
+
+  // NOTE beforeEach() runs _after_ the beforeAll() hooks of the describe() blocks
+  beforeEach(done => {
+    stylelint
+      .lint({
+        code,
+        codeFilename,
+        syntax: 'scss',
+        config: {
+          processors: [processor],
+          rules
+        }
+      })
+      .then(result => {
+        data = result
+        done()
+      })
+      .catch(err => {
+        // eslint-disable-next-line
+        console.log(err)
+        data = err
+        done()
+      })
+  })
+
+  describe('no codeFilename', () => {
+    beforeAll(() => {})
+
+    it('should have one result', () => {
+      expect(data.results.length).toEqual(1)
+    })
+
+    it('should use the right file', () => {
+      expect(data.results[0].source).toEqual('<input css 2>')
+    })
+
+    it('should have errored', () => {
+      expect(data.errored).toEqual(true)
+    })
+
+    it('should have one warnings', () => {
+      expect(data.results[0].warnings.length).toEqual(1)
+    })
+
+    it('should have the right line number', () => {
+      expect(data.results[0].warnings[0].line).toEqual(3)
+    })
+  })
+
+  describe('not existed codeFilename', () => {
+    beforeAll(() => {
+      codeFilename = 'not-existed-file'
+    })
+
+    it('should have one result', () => {
+      expect(data.results.length).toEqual(1)
+    })
+
+    it('should use the right file', () => {
+      expect(data.results[0].source).toEqual('<input css 7>')
+    })
+
+    it('should have errored', () => {
+      expect(data.errored).toEqual(true)
+    })
+
+    it('should have one warnings', () => {
+      expect(data.results[0].warnings.length).toEqual(1)
+    })
+
+    it('should have the right line number', () => {
+      expect(data.results[0].warnings[0].line).toEqual(3)
+    })
+  })
+
+  describe('existed codeFilename', () => {
+    beforeAll(() => {
+      codeFilename = 'package.json'
+    })
+
+    it('should have one result', () => {
+      expect(data.results.length).toEqual(1)
+    })
+
+    it('should use the right file', () => {
+      expect(data.results[0].source).toEqual(path.resolve(process.cwd(), codeFilename))
+    })
+
+    it('should have errored', () => {
+      expect(data.errored).toEqual(true)
+    })
+
+    it('should have one warnings', () => {
+      expect(data.results[0].warnings.length).toEqual(1)
+    })
+
+    it('should have the right line number', () => {
+      expect(data.results[0].warnings[0].line).toEqual(3)
+    })
+  })
+})

--- a/test/nofiles.test.js
+++ b/test/nofiles.test.js
@@ -39,13 +39,16 @@ describe('no files', () => {
   })
 
   describe('no codeFilename', () => {
-    beforeAll(() => {})
+    beforeAll(() => {
+      codeFilename = undefined
+    })
 
     it('should have one result', () => {
       expect(data.results.length).toEqual(1)
     })
 
     it('should use the right file', () => {
+      // Every new linting that occurs in beforeEach() will increase the id
       expect(data.results[0].source).toEqual('<input css 2>')
     })
 
@@ -53,7 +56,7 @@ describe('no files', () => {
       expect(data.errored).toEqual(true)
     })
 
-    it('should have one warnings', () => {
+    it('should have one warning', () => {
       expect(data.results[0].warnings.length).toEqual(1)
     })
 
@@ -79,7 +82,7 @@ describe('no files', () => {
       expect(data.errored).toEqual(true)
     })
 
-    it('should have one warnings', () => {
+    it('should have one warning', () => {
       expect(data.results[0].warnings.length).toEqual(1)
     })
 


### PR DESCRIPTION
Fixes #76. The input id matches [the logic of postcss](https://github.com/postcss/postcss/blob/master/lib/input.es6#L78).

Please notice that current `package-lock.json` uses `stylelint@8.0.0`, which doesn't validate the existence of `codeFilename`. But from [8.1.0](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#810), non-existed `codeFilename` will also cause `filepath` to be undefined. If you want to upgrade `stylelint`, my second commit can be reverted.