### PR TITLE
Increase async test timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -822,7 +822,7 @@
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -4733,7 +4733,7 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38=",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -4744,7 +4744,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
+  "jest": {
+    "setupTestFrameworkScriptFile": "./test/jest-setup.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/styled-components/stylelint-processor-styled-components.git"

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -1,0 +1,2 @@
+const ASYNC_TEST_TIMEOUT = process.env.CI ? 20 * 1000 : 5 * 1000
+jest.setTimeout(ASYNC_TEST_TIMEOUT)


### PR DESCRIPTION
I was just getting sick of all the failed Travis builds which were mostly due to timeouts when doing the coverage which I guess makes the tests take that little longer that makes the tests time out on the relatively slow CI CPU, so added this.

I guess this should just be mergeable, but for good measure if @mxstbr or @ismay could just approve it?