### PR TITLE
Add test cases for line comments

### DIFF
--- a/test/fixtures/hard/valid-js-comments.js
+++ b/test/fixtures/hard/valid-js-comments.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const Button1 = styled.div`
+  color: red;
+  display: block;
+  // Some comment
+  margin: 20px 30px 40px 50px; // comment after line
+  padding: 20px;
+`;
+

--- a/test/hard.test.js
+++ b/test/hard.test.js
@@ -134,4 +134,29 @@ describe('hard', () => {
       expect(data.results[0].warnings[4].line).toEqual(35)
     })
   })
+
+  describe('js style comments', () => {
+    describe('valid', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/hard/valid-js-comments.js')
+      })
+
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
+
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+        console.log(data.results[0])
+      })
+
+      it('should not have errored', () => {
+        expect(data.errored).toEqual(false)
+      })
+
+      it('should not have any warnings', () => {
+        expect(data.results[0].warnings).toEqual([])
+      })
+    })
+  })
 })


### PR DESCRIPTION
Test cases for JS style line comments, this should close #156 either by adding the functionality if we find out it is actually broken or just by merging this PR with the passing tests that properly document that we support this