### PR TITLE
Use stylelint-config-recommend in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ You need:
 - `stylelint` (duh)
 - This processor, to extract styles from `styled-components`
 - The [`stylelint-config-styled-components`](https://github.com/styled-components/stylelint-config-styled-components) config to disable stylelint rules that clash with `styled-components`
-- Your favorite `stylelint` config! (for example [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard))
+- Your favorite `stylelint` config! (for example [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended))
 
 ```
 (npm install --save-dev
   stylelint
   stylelint-processor-styled-components
   stylelint-config-styled-components
-  stylelint-config-standard)
+  stylelint-config-recommended)
 ```
 
 Now use those in your `.stylelintrc` and run stylelint with your JavaScript files!
@@ -32,7 +32,7 @@ Now use those in your `.stylelintrc` and run stylelint with your JavaScript file
 {
   "processors": ["stylelint-processor-styled-components"],
   "extends": [
-    "stylelint-config-standard",
+    "stylelint-config-recommended",
     "stylelint-config-styled-components"
   ],
   "syntax": "scss"


### PR DESCRIPTION
A minor doc change that swaps [stylelint-config-recommend](https://github.com/stylelint/stylelint-config-recommended) in for [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard).  I suspect this config will be more useful to the majority of the users of this processor at it works well with pretty-printers like Prettier. Whereas, the _stylistic_ rules in stylelint-config-standard can sometimes conflict with them.

Incidentally, I believe this could make the lack of `--fix` support in processors less of a limitation as the majority of non-stylistic rules can't be automatically fixed e.g. rules that:

   - [check CSS code for mistakes](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#possible-errors) and surface bugs earlier (e.g. [overriding shorthand properties](https://github.com/stylelint/stylelint/blob/master/lib/rules/declaration-block-no-shorthand-property-overrides/README.md))
   - [enforce non-stylistic conventions](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#limit-language-features) and make CSS more consistent (e.g. [limiting what units can be used](https://github.com/stylelint/stylelint/blob/master/lib/rules/unit-whitelist/README.md)) 

The CSS-Tricks' [_Prettier + Stylelint: Writing Very Clean CSS (Or, Keeping Clean Code is a Two-Tool Game)_](https://css-tricks.com/prettier-stylelint-writing-clean-css-keeping-clean-code-two-tool-game/) article does a great job of detailing how Prettier and stylelint go well together.