### PR TITLE
Fixed interpolations following a multiline comment

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -67,7 +67,7 @@ const reverseString = str => str.split('').reverse().join('')
 
 const isLastDeclarationCompleted = text => {
   // We disregard all comments in this assessment of declaration completion
-  const commentsRemoved = text.replace(/\/\*.*?\*\//g, '')
+  const commentsRemoved = text.replace(/\/\*[\s\S]*?\*\//g, '')
   const reversedText = reverseString(commentsRemoved)
   const lastNonWhitespaceChar = nextNonWhitespaceChar(reversedText)
   if (

--- a/test/fixtures/interpolations/valid.js
+++ b/test/fixtures/interpolations/valid.js
@@ -116,3 +116,19 @@ const Button12 = styled.button`
   /* stylelint-disable */
   ${colorExpression}
 `
+
+const Button13 = styled.button`
+  display: block;
+  /*
+    multiline comment with "*" and "/"
+  */
+  ${colorExpression}
+`
+
+const Button14 = styled.button`
+  display: block;
+  /**
+   * JSDoc style comment
+   */
+  ${colorExpression}
+`

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -368,15 +368,47 @@ describe('utils', () => {
       expect(fn(prevCSS2)).toBe(true)
 
       const prevCSS3 = `
-        display: /* stylelint-disable */
+      display: block;
+      /*
+        multiline comment with "*" and "/"
+      */
         `
-      expect(fn(prevCSS3)).toBe(false)
+      expect(fn(prevCSS3)).toBe(true)
 
       const prevCSS4 = `
+      display: block;
+      /*
+       * JSDoc style comment
+       */
+        `
+      expect(fn(prevCSS4)).toBe(true)
+
+      const prevCSS5 = `
+        display: /* stylelint-disable */
+        `
+      expect(fn(prevCSS5)).toBe(false)
+
+      const prevCSS6 = `
       display:
       /* stylelint-disable */
         `
-      expect(fn(prevCSS4)).toBe(false)
+      expect(fn(prevCSS6)).toBe(false)
+
+      const prevCSS7 = `
+      display:
+      /*
+        multiline comment with "*" and "/"
+      */
+        `
+      expect(fn(prevCSS7)).toBe(false)
+
+      const prevCSS8 = `
+      display:
+      /*
+       * JSDoc style comment
+       */
+        `
+      expect(fn(prevCSS8)).toBe(false)
     })
   })
 


### PR DESCRIPTION
The previous PR #84 fixed comments before interpolations but does not work for multiline comments.

The updated RegEx will now match any characters that are not `*/` (https://regexr.com/3m0r1).

```css
/* single line */
display: block;

/* 
  multiline with "*" and "/"
*/
display: block;


/** 
 * JsDoc style
 */
display: block;
```