### PR TITLE
Add 'optionalChaining' to babylon-parser

### DIFF
--- a/src/parsers/babylon-parser.js
+++ b/src/parsers/babylon-parser.js
@@ -14,6 +14,7 @@ module.exports = type => input =>
       'functionBind',
       'functionSent',
       'dynamicImport',
-      'optionalCatchBinding'
+      'optionalCatchBinding',
+      'optionalChaining'
     ]
   })


### PR DESCRIPTION
As discussed in #183 this will be the first quick fix with adding `optionalChainging` to the plugin list.