### PR TITLE
Remove extra npm install

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 4
+        "node": 6
       }
     }]
   ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "7"
   - "8"
 before_install:
-  - npm i -g npm
   - npm i -g greenkeeper-lockfile@1
   - npm i -g coveralls
 install:


### PR DESCRIPTION
Usually, `npm` is installed with `nodejs`. And latest npm@6.1.0 is not compatible with nodejs@4, which will break our CI.