### PR TITLE
Remove installing latest npm in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "7"
   - "8"
 before_install:
-  - npm i -g npm
   - npm i -g greenkeeper-lockfile@1
   - npm i -g coveralls
 install:


### PR DESCRIPTION
It's making node v4 fail because I guess the latest version of npm isn't compatible with it, and I think it should also be okay using the version of npm that comes with each node version in the CI?