### PR TITLE
allow overriding import name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ const interpolationLinesMap = {}
 const sourceMapsCorrections = {}
 const errorWasThrown = {}
 const DEFAULT_OPTIONS = {
-  moduleName: 'styled-components'
+  moduleName: 'styled-components',
+  importName: 'default'
 }
 
 module.exports = options => ({

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -47,7 +47,11 @@ const processStyledComponentsFile = (ast, absolutePath, options) => {
       if (hasAttrsCall(node)) {
         processedNode.tag = getAttrsObject(node)
       }
-      if (!helper && !isStyled(processedNode, importedNames.default) && !isExtendCall(node)) {
+      if (
+        !helper &&
+        !isStyled(processedNode, importedNames[options.importName]) &&
+        !isExtendCall(node)
+      ) {
         return
       }
       const content = getTTLContent(node, absolutePath)

--- a/test/fixtures/options/import-name.js
+++ b/test/fixtures/options/import-name.js
@@ -1,0 +1,6 @@
+import { notDefault } from 'styled-components'
+
+// ⚠️ EMPTY BLOCK ⚠️
+const Button = notDefault.div`
+
+`

--- a/test/fixtures/options/invalid-import-name.js
+++ b/test/fixtures/options/invalid-import-name.js
@@ -1,0 +1,8 @@
+import { something } from 'styled-components'
+
+
+// Empty block, but moduleName isn't set to some-lib
+// so shouldn't be an error
+const Button = something.div`
+
+`

--- a/test/fixtures/options/invalid-import-name.js
+++ b/test/fixtures/options/invalid-import-name.js
@@ -1,7 +1,7 @@
 import { something } from 'styled-components'
 
 
-// Empty block, but moduleName isn't set to some-lib
+// Empty block, but importName isn't set to `something`
 // so shouldn't be an error
 const Button = something.div`
 

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -19,96 +19,168 @@ describe('options', () => {
   let fixture
   let data
 
-  // NOTE beforeEach() runs _after_ the beforeAll() hooks of the describe() blocks, so `fixture`
-  // will have the right path
-  beforeEach(done => {
-    stylelint
-      .lint({
-        files: [fixture],
-        config: {
-          // Set moduleName option to "emotion"
-          processors: [[processor, { moduleName: 'emotion' }]],
-          rules
-        }
-      })
-      .then(result => {
-        data = result
-        done()
-      })
-      .catch(err => {
-        console.log(err)
-        data = err
-        done()
-      })
-  })
-
   describe('moduleName', () => {
-    beforeAll(() => {
-      fixture = path.join(__dirname, './fixtures/options/module-name.js')
+    // NOTE beforeEach() runs _after_ the beforeAll() hooks of the describe() blocks, so `fixture`
+    // will have the right path
+    beforeEach(done => {
+      stylelint
+        .lint({
+          files: [fixture],
+          config: {
+            // Set moduleName option to "emotion"
+            processors: [[processor, { moduleName: 'emotion' }]],
+            rules
+          }
+        })
+        .then(result => {
+          data = result
+          done()
+        })
+        .catch(err => {
+          console.log(err)
+          data = err
+          done()
+        })
     })
 
-    it('should have one result', () => {
-      expect(data.results.length).toEqual(1)
+    describe('moduleName', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/options/module-name.js')
+      })
+
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
+
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+      })
+
+      it('should have errored', () => {
+        expect(data.results[0].errored).toEqual(true)
+      })
+
+      it('should have one warning (i.e. wrong lines of code)', () => {
+        expect(data.results[0].warnings.length).toEqual(1)
+      })
+
+      it('should have a block-no-empty as the first warning', () => {
+        expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+      })
     })
 
-    it('should use the right file', () => {
-      expect(data.results[0].source).toEqual(fixture)
+    describe('relative moduleName', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/options/relative-module-name.js')
+      })
+
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
+
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+      })
+
+      it('should have errored', () => {
+        expect(data.results[0].errored).toEqual(true)
+      })
+
+      it('should have one warning (i.e. wrong lines of code)', () => {
+        expect(data.results[0].warnings.length).toEqual(1)
+      })
+
+      it('should have a block-no-empty as the first warning', () => {
+        expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+      })
     })
 
-    it('should have errored', () => {
-      expect(data.results[0].errored).toEqual(true)
-    })
+    describe('invalid moduleName', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/options/invalid-module-name.js')
+      })
 
-    it('should have one warning (i.e. wrong lines of code)', () => {
-      expect(data.results[0].warnings.length).toEqual(1)
-    })
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
 
-    it('should have a block-no-empty as the first warning', () => {
-      expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+      })
+
+      it('should not have errored', () => {
+        expect(data.results[0].errored).toEqual(undefined)
+      })
     })
   })
 
-  describe('relative moduleName', () => {
-    beforeAll(() => {
-      fixture = path.join(__dirname, './fixtures/options/relative-module-name.js')
+  describe('importName', () => {
+    // NOTE beforeEach() runs _after_ the beforeAll() hooks of the describe() blocks, so `fixture`
+    // will have the right path
+    beforeEach(done => {
+      stylelint
+        .lint({
+          files: [fixture],
+          config: {
+            // Set moduleName option to "emotion"
+            processors: [[processor, { importName: 'notDefault' }]],
+            rules
+          }
+        })
+        .then(result => {
+          data = result
+          done()
+        })
+        .catch(err => {
+          console.log(err)
+          data = err
+          done()
+        })
     })
 
-    it('should have one result', () => {
-      expect(data.results.length).toEqual(1)
+    describe('importName', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/options/import-name.js')
+      })
+
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
+
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+      })
+
+      it('should have errored', () => {
+        expect(data.results[0].errored).toEqual(true)
+      })
+
+      it('should have one warning (i.e. wrong lines of code)', () => {
+        expect(data.results[0].warnings.length).toEqual(1)
+      })
+
+      it('should have a block-no-empty as the first warning', () => {
+        expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+      })
     })
 
-    it('should use the right file', () => {
-      expect(data.results[0].source).toEqual(fixture)
-    })
+    describe('invalid importName', () => {
+      beforeAll(() => {
+        fixture = path.join(__dirname, './fixtures/options/invalid-import-name.js')
+      })
 
-    it('should have errored', () => {
-      expect(data.results[0].errored).toEqual(true)
-    })
+      it('should have one result', () => {
+        expect(data.results.length).toEqual(1)
+      })
 
-    it('should have one warning (i.e. wrong lines of code)', () => {
-      expect(data.results[0].warnings.length).toEqual(1)
-    })
+      it('should use the right file', () => {
+        expect(data.results[0].source).toEqual(fixture)
+      })
 
-    it('should have a block-no-empty as the first warning', () => {
-      expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
-    })
-  })
-
-  describe('invalid moduleName', () => {
-    beforeAll(() => {
-      fixture = path.join(__dirname, './fixtures/options/invalid-module-name.js')
-    })
-
-    it('should have one result', () => {
-      expect(data.results.length).toEqual(1)
-    })
-
-    it('should use the right file', () => {
-      expect(data.results[0].source).toEqual(fixture)
-    })
-
-    it('should not have errored', () => {
-      expect(data.results[0].errored).toEqual(undefined)
+      it('should not have errored', () => {
+        console.log(data)
+        expect(data.results[0].errored).toEqual(undefined)
+      })
     })
   })
 })


### PR DESCRIPTION
Hi!

this PR allows the user to override the import name (currently it's set to "default"). 

In our project we have a file that re-exports Styled with type parameters. The problem is that we use a named export instead of a default export. 