### PR TITLE
Clean parse error on success parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ const path = require('path')
 const parse = require('./parsers/index')
 
 let inputId = 1
+// Make sure that state for particular path will be cleaned before each run
+// module may be kept in memory when used with vscode-stylelint
 const interpolationLinesMap = {}
 const sourceMapsCorrections = {}
 const errorWasThrown = {}
@@ -37,22 +39,16 @@ module.exports = options => ({
     }
 
     try {
-      sourceMapsCorrections[absolutePath] = {}
+      delete errorWasThrown[absolutePath]
       const { extractedCSS, interpolationLines, sourceMap } = parse(
         input,
         absolutePath,
         Object.assign({}, DEFAULT_OPTIONS, options)
       )
       // Save dummy interpolation lines
-      interpolationLinesMap[absolutePath] = interpolationLines.concat(
-        interpolationLinesMap[absolutePath] || []
-      )
-      // Save source location, merging existing corrections with current corrections
-      sourceMapsCorrections[absolutePath] = Object.assign(
-        sourceMapsCorrections[absolutePath],
-        sourceMap
-      )
-      delete errorWasThrown[absolutePath]
+      interpolationLinesMap[absolutePath] = interpolationLines
+      // Save source location
+      sourceMapsCorrections[absolutePath] = sourceMap
       return extractedCSS
     } catch (e) {
       // Always save the error

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ module.exports = options => ({
         sourceMapsCorrections[absolutePath],
         sourceMap
       )
+      delete errorWasThrown[absolutePath]
       return extractedCSS
     } catch (e) {
       // Always save the error


### PR DESCRIPTION
When used with vscode-stylelint extension, the entire module will be loaded and kept in memory, thus sharing state between various validate requests. The problem comes when file had parsing error (due incorrect syntax or incomplete statements - vscode sends validate request while you're typing something) it will store parse error into ```errorWasThrown``` shared object. Since the module is preserved in memory, subsequent runs will return this error due to this line https://github.com/styled-components/stylelint-processor-styled-components/blob/d055954273328a2fb11b48d5b48533b2afdadce7/src/index.js#L69 even for perfectly valid file.