### PR TITLE
add `strict` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ const sourceMapsCorrections = {}
 const errorWasThrown = {}
 const DEFAULT_OPTIONS = {
   moduleName: 'styled-components',
-  importName: 'default'
+  importName: 'default',
+  strict: false
 }
 
 module.exports = options => ({

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -44,7 +44,9 @@ const processStyledComponentsFile = (ast, absolutePath, options) => {
         importedNames = parseImports(node)
         return
       }
-      const helper = isHelper(node, importedNames)
+      const helper = !options.strict
+        ? isHelper(node, importedNames)
+        : isHelper(node, [importedNames[options.importName]])
       const processedNode = Object.assign({}, node)
       if (hasAttrsCall(node)) {
         processedNode.tag = getAttrsObject(node)

--- a/test/fixtures/options/strict.js
+++ b/test/fixtures/options/strict.js
@@ -1,0 +1,9 @@
+import { foo, bar } from 'some-module'
+
+// EMPTY BLOCK
+const Button = foo`
+
+`;
+const Button2 = bar`
+
+`;

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -231,4 +231,57 @@ describe('options', () => {
       expect(data.results[0].errored).toEqual(undefined)
     })
   })
+
+  describe('strict', () => {
+    beforeEach(done => {
+      fixture = path.join(__dirname, './fixtures/options/strict.js')
+
+      stylelint
+        .lint({
+          files: [fixture],
+          config: {
+            processors: [
+              [
+                processor,
+                {
+                  moduleName: 'some-module',
+                  importName: 'foo',
+                  strict: true
+                }
+              ]
+            ],
+            rules
+          }
+        })
+        .then(result => {
+          data = result
+          done()
+        })
+        .catch(err => {
+          console.log(err)
+          data = err
+          done()
+        })
+    })
+
+    it('should have one result', () => {
+      expect(data.results.length).toEqual(1)
+    })
+
+    it('should use the right file', () => {
+      expect(data.results[0].source).toEqual(fixture)
+    })
+
+    it('should have errored', () => {
+      expect(data.results[0].errored).toEqual(true)
+    })
+
+    it('should have one warning (i.e. wrong lines of code)', () => {
+      expect(data.results[0].warnings.length).toEqual(1)
+    })
+
+    it('should have a block-no-empty as the first warning', () => {
+      expect(data.results[0].warnings[0].rule).toEqual('block-no-empty')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #253.

Enables stricter parsing, in that only expressions using the specified
`importName` from the `moduleName` will be parsed.

```ts
// moduleName = some-module, importName = foo
import { foo, bar } from 'some-module';
foo`test`; // parsed
bar`test`; // parsed
foo.bleh`test`; // parsed
bar.bleh`test`; // parsed

// moduleName = some-module, importName = foo, strict = true
import { foo, bar } from 'some-module';
foo`test`; // parsed
bar`test`; // ignored
foo.bleh`test`; // parsed
bar.bleh`test`; // ignored
```