### PR TITLE
feat(selector-guessing): improve guess at selector

### DIFF
--- a/src/utils/tagged-template-literal.js
+++ b/src/utils/tagged-template-literal.js
@@ -130,7 +130,7 @@ const interleave = (quasis, expressions, absolutePath) => {
       substitute = parseInterpolationTag(expressions[i], count, absolutePath)
       count += 1
       // No sc tag so we guess defaults
-    } else if (nextChar === '{') {
+    } else if (nextChar === '{' || ['>', '&'].includes(prevChar)) {
       // Guess as selector, which shares format with `parseInterpolationTag`, but not `wrapSelector`
       substitute = `.sc-selector${count}`
       count += 1


### PR DESCRIPTION
This is a bit of a selfish PR, but I was thinking we could be just a bit smarter about guessing whether an interpolation is a selector or not. I don't think that `&` and `>` aren valid tokens in CSS for anything other than as part of a selector, so we could use those to reduce the need for sc tags. This helps in cases like the following (very common in our code base, don't know how common in others):

```
const SomeCompnent = styled(MyComponent)`
  & > ${SomeChild},
  & > ${OtherChild} {
    color: blue;
  }
`
```

`SomeChild` would not be identified as a selector since it is part of a list of selectors. Commas a valid CSS tokens in lots of scenarios, so looking for that is not really an option, but `&` and `>` are only valid as part of a selector (I don't think 🤔 ), so it would at least cover those. Thoughts? Am I way off base here?