### PR TITLE
Add ?? support to default parser plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ And it also has some options. Their default values are,
       "functionBind",
       "functionSent",
       "dynamicImport",
+      "nullishCoalescingOperator",
       "optionalCatchBinding",
       "optionalChaining"
     ]

--- a/src/parsers/babylon-parser.js
+++ b/src/parsers/babylon-parser.js
@@ -14,6 +14,7 @@ module.exports = (type, plugins) => input =>
         'functionBind',
         'functionSent',
         'dynamicImport',
+        'nullishCoalescingOperator',
         'optionalCatchBinding',
         'optionalChaining'
       ]

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -197,6 +197,7 @@ describe('options', () => {
         'functionBind',
         'functionSent',
         'dynamicImport',
+        'nullishCoalescingOperator',
         'optionalCatchBinding',
         'optionalChaining',
         // Enable experimental feature


### PR DESCRIPTION
I had to add this to my proejct's stylelint config to get my stylelint working after adopting nullish coalescing in my codebase.

Now that Nullish Coalesce is stage 3, and it's enabled by default in projects like Typescript, this might be a useful default to add. Since optional chaining support is already in, this shouldn't be a too radical change. Just a proposal!