### PR TITLE
Readme: Setup allow copy paste of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ You need:
 - Your favorite `stylelint` config! (for example [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended))
 
 ```
-(npm install --save-dev
-  stylelint
-  stylelint-processor-styled-components
-  stylelint-config-styled-components
+(npm install --save-dev \
+  stylelint \
+  stylelint-processor-styled-components \
+  stylelint-config-styled-components \
   stylelint-config-recommended)
 ```
 


### PR DESCRIPTION
At least in my bash shell when copy pasting the `npm install ...` it's running a full install and complains that all the libs are no bash commands.