### PR TITLE
Update Babel parser for Typescript 3.8 syntax support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,9 +100,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+      "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
     },
     "@babel/plugin-syntax-bigint": {
       "version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "stylelint": ">= 10"
   },
   "dependencies": {
-    "@babel/parser": "^7.8.3",
+    "@babel/parser": "^7.10.2",
     "@babel/traverse": "^7.8.3",
     "micromatch": "^4.0.2",
     "postcss": "^7.0.26"


### PR DESCRIPTION
Currently, `stylelint-processor-styled-components` does not support the new syntax from Typescript 3.8, like
```typescript
export type { Foo } from './foo';
```

This PR fixes that.