### PR TITLE
Add importMeta to babylon-parser

### DIFF
--- a/src/parsers/babylon-parser.js
+++ b/src/parsers/babylon-parser.js
@@ -10,7 +10,8 @@ module.exports = (type, plugins) => input =>
         'classProperties',
         'exportExtensions',
         'functionBind',
-        'functionSent'
+        'functionSent',
+        'importMeta'
       ]
     )
   })


### PR DESCRIPTION
Adding importMeta to babylon-parser to allow for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta

This error came up when parsing a file using [Vite](https://vitejs.dev/) with environment variables